### PR TITLE
Uses the same base64 unpadded encoding output as chainweb

### DIFF
--- a/lib/Chainweb/Api/Base64Url.hs
+++ b/lib/Chainweb/Api/Base64Url.hs
@@ -11,8 +11,6 @@ import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 ------------------------------------------------------------------------------
-import           Chainweb.Api.MinerData
-------------------------------------------------------------------------------
 
 newtype Base64Url a = Base64Url { fromBase64Url :: a }
   deriving (Eq,Ord,Show)
@@ -34,6 +32,6 @@ decodeB64UrlNoPaddingText = B64U.decode . T.encodeUtf8 . pad
 -- | Encode a binary value to a textual base64-url without padding
 -- representation.
 --
-encodeB64UrlNoPaddingText :: B.ByteString -> T.Text
+encodeB64UrlNoPaddingText :: ByteString -> T.Text
 encodeB64UrlNoPaddingText = T.dropWhileEnd (== '=') . T.decodeUtf8 . B64U.encode
 

--- a/lib/Chainweb/Api/Base64Url.hs
+++ b/lib/Chainweb/Api/Base64Url.hs
@@ -29,19 +29,11 @@ decodeB64UrlNoPaddingText = B64U.decode . T.encodeUtf8 . pad
   where
     pad t = let s = T.length t `mod` 4 in t <> T.replicate ((4 - s) `mod` 4) "="
 
-data Block = Block
-  { blockHeight :: Int
-  , blockChain  :: Int
-  , blockMiner  :: MinerData
-  } deriving (Eq,Ord,Show)
+-- Copied from chainweb-node
 
-instance FromJSON Block where
-  parseJSON = withObject "Block" $ \o -> Block
-    <$> o .: "height"
-    <*> o .: "chainId"
-    <*> (parseJSON =<< fmap baz (o .: "minerData"))
+-- | Encode a binary value to a textual base64-url without padding
+-- representation.
+--
+encodeB64UrlNoPaddingText :: B.ByteString -> T.Text
+encodeB64UrlNoPaddingText = T.dropWhileEnd (== '=') . T.decodeUtf8 . B64U.encode
 
-baz :: Value -> Value
-baz (String t) =
-  either (error "aoeuhtnaoehtn") id $ eitherDecodeStrict =<< decodeB64UrlNoPaddingText t
-baz v = v

--- a/lib/Chainweb/Api/Hash.hs
+++ b/lib/Chainweb/Api/Hash.hs
@@ -5,7 +5,6 @@ import           Data.Aeson
 import           Data.Aeson.Types
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as B16
-import qualified Data.ByteString.Base64.URL as B64U
 import           Data.Text (Text)
 import qualified Data.Text.Encoding as T
 ------------------------------------------------------------------------------

--- a/lib/Chainweb/Api/Hash.hs
+++ b/lib/Chainweb/Api/Hash.hs
@@ -25,4 +25,5 @@ hashHex :: Hash -> Text
 hashHex = T.decodeUtf8 . B16.encode . unHash
 
 hashB64U :: Hash -> Text
-hashB64U = T.decodeUtf8 . B64U.encode . unHash
+hashB64U = encodeB64UrlNoPaddingText . unHash
+


### PR DESCRIPTION
This should help reduce the proliferation of hashes that have the equals
sign padding at the end and make everything a lot more consistent with
exact chainweb-node hashes.

Also removes some dead code.