### PR TITLE
WIP: add pact types

### DIFF
--- a/chainweb-api.cabal
+++ b/chainweb-api.cabal
@@ -31,10 +31,13 @@ library
     , data-default          ^>=0.7
     , hashable              >=1.2 && < 1.4
     , readable              ^>=0.3
+    , scientific
     , servant               ^>=0.16
     , text                  ^>=1.2
     , time                  >=1.8 && < 1.11
     , unordered-containers  ^>=0.2
+    , vector
+    , lens
 
   if !impl(ghcjs)
     build-depends:
@@ -48,6 +51,7 @@ library
     Chainweb.Api.BlockPayload
     Chainweb.Api.BlockPayloadWithOutputs
     Chainweb.Api.BytesLE
+    Chainweb.Api.CommandResult
     Chainweb.Api.ChainId
     Chainweb.Api.ChainTip
     Chainweb.Api.ChainwebMeta
@@ -57,6 +61,7 @@ library
     Chainweb.Api.MinerData
     Chainweb.Api.NodeInfo
     Chainweb.Api.PactCommand
+    Chainweb.Api.PactTypes
     Chainweb.Api.Payload
     Chainweb.Api.RespItems
     Chainweb.Api.Sig
@@ -68,6 +73,7 @@ library
     ChainwebData.TxSummary
     ChainwebData.TxDetail
     ChainwebData.Util
+    Crypto.Hash.Blake2Native
 
 test-suite testsuite
     default-language: Haskell2010

--- a/lib/Chainweb/Api/Base64Url.hs
+++ b/lib/Chainweb/Api/Base64Url.hs
@@ -15,6 +15,9 @@ import qualified Data.Text.Encoding as T
 newtype Base64Url a = Base64Url { fromBase64Url :: a }
   deriving (Eq,Ord,Show)
 
+instance ToJSON a => ToJSON (Base64Url a) where
+  toJSON (Base64Url a) = toJSON a
+
 instance FromJSON a => FromJSON (Base64Url a) where
   parseJSON = withText "Base64Url" $ \t ->
     case decodeB64UrlNoPaddingText t of

--- a/lib/Chainweb/Api/ChainId.hs
+++ b/lib/Chainweb/Api/ChainId.hs
@@ -25,10 +25,17 @@ chainIdFromText
   = maybe (fail "ChainId string was not an integer") (pure . ChainId)
   . readMaybe . T.unpack
 
+instance ToJSON ChainId where
+  toJSON = toJSON
+
 instance FromJSON ChainId where
   parseJSON v =
         withText "ChainId" chainIdFromText v
     <|> withScientific "ChainId" (pure . ChainId . round) v
+
+--TODO: Is this right?
+instance ToJSONKey ChainId where
+  toJSONKey = toJSONKey
 
 instance FromJSONKey ChainId where
   fromJSONKey = FromJSONKeyTextParser chainIdFromText

--- a/lib/Chainweb/Api/ChainwebMeta.hs
+++ b/lib/Chainweb/Api/ChainwebMeta.hs
@@ -11,7 +11,7 @@ import Data.Time.Clock.POSIX
 
 data ChainwebMeta = ChainwebMeta
   { _chainwebMeta_chainId      :: Text
-  , _chainwebMeta_creationTime :: POSIXTime
+  , _chainwebMeta_creationTime :: POSIXTime --UTC TIme? Or POSIX time?
   , _chainwebMeta_ttl          :: Int
   , _chainwebMeta_gasLimit     :: Int
   , _chainwebMeta_gasPrice     :: Double
@@ -20,12 +20,12 @@ data ChainwebMeta = ChainwebMeta
 
 instance ToJSON ChainwebMeta where
   toJSON ChainwebMeta{..} = object
-    [ "chainId" .= _chainwebMeta_chainId
+    [ "chainId"      .= _chainwebMeta_chainId
     , "creationTime" .= _chainwebMeta_creationTime
-    , "ttl" .= _chainwebMeta_ttl
-    , "gasLimit" .= _chainwebMeta_gasLimit
-    , "gasPrice" .= _chainwebMeta_gasPrice
-    , "sender" .= _chainwebMeta_sender
+    , "ttl"          .= _chainwebMeta_ttl
+    , "gasLimit"     .= _chainwebMeta_gasLimit
+    , "gasPrice"     .= _chainwebMeta_gasPrice
+    , "sender"       .= _chainwebMeta_sender
     ]
 
 instance FromJSON ChainwebMeta where

--- a/lib/Chainweb/Api/ChainwebMeta.hs
+++ b/lib/Chainweb/Api/ChainwebMeta.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Chainweb.Api.ChainwebMeta where
 
@@ -16,6 +17,16 @@ data ChainwebMeta = ChainwebMeta
   , _chainwebMeta_gasPrice     :: Double
   , _chainwebMeta_sender       :: Text
   } deriving (Eq,Ord,Show)
+
+instance ToJSON ChainwebMeta where
+  toJSON ChainwebMeta{..} = object
+    [ "chainId" .= _chainwebMeta_chainId
+    , "creationTime" .= _chainwebMeta_creationTime
+    , "ttl" .= _chainwebMeta_ttl
+    , "gasLimit" .= _chainwebMeta_gasLimit
+    , "gasPrice" .= _chainwebMeta_gasPrice
+    , "sender" .= _chainwebMeta_sender
+    ]
 
 instance FromJSON ChainwebMeta where
   parseJSON = withObject "ChainwebMeta" $ \o -> ChainwebMeta

--- a/lib/Chainweb/Api/CommandResult.hs
+++ b/lib/Chainweb/Api/CommandResult.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Chainweb.Api.CommandResult where
+
+------------------------------------------------------------------------------
+import           Data.Aeson
+import           Data.Text (Text)
+------------------------------------------------------------------------------
+import Chainweb.Api.PactTypes
+import Chainweb.Api.ChainwebMeta
+------------------------------------------------------------------------------
+
+data ResultMetaData = ResultMetaData
+  { _resultMetaData_chainwebMeta  :: Maybe ChainwebMeta  -- only on locals
+  , _resultMetaData_blockTime     :: Text
+  , _resultMetaData_blockHash     :: Maybe Text   -- only on send
+  , _resultMetaData_prevBlockHash :: Text
+  , _resultMetaData_blockHeight   :: Int
+  } deriving (Show, Eq)
+
+instance FromJSON ResultMetaData where
+  parseJSON = withObject "ResultMetaData" $ \o -> ResultMetaData
+    <$> o .:? "publicMeta"
+    <*> o .:  "blockTime"
+    <*> o .:? "blockHash"
+    <*> o .:  "prevBlockHash"
+    <*> o .:  "blockHeight"
+
+data CommandResult = CommandResult
+  { _commandResult_requestKey    :: Text
+  , _commandResult_result        :: PactResult
+  , _commandResult_transactionID :: Maybe Int
+  , _commandResult_gas           :: Int
+  , _commandResult_logReference  :: Maybe Text
+  , _commandResult_meta          :: Maybe ResultMetaData
+  , _commandResult_continuation  :: Maybe PactContinuationResult
+  , _commandResult_events        :: Maybe [PactEvent]
+  } deriving (Show, Eq)
+
+instance FromJSON CommandResult where
+  parseJSON = withObject "CommandResult" $ \o -> CommandResult
+    <$> o .:  "reqKey"
+    <*> o .:  "result"
+    <*> o .:? "txId"
+    <*> o .:  "gas"
+    <*> o .:? "logs"
+    <*> o .:? "metaData"
+    <*> o .:? "continuation"
+    <*> o .:? "events"

--- a/lib/Chainweb/Api/Hash.hs
+++ b/lib/Chainweb/Api/Hash.hs
@@ -15,6 +15,9 @@ import           Chainweb.Api.Base64Url
 newtype Hash = Hash { unHash :: ByteString }
   deriving (Eq,Ord,Show,Read)
 
+instance ToJSON Hash where
+  toJSON hash = String $ hashB64U hash
+
 instance FromJSON Hash where
   parseJSON (String t) =
     either (\e -> fail $ "Base64Url parse failed: " <> e) (return . Hash) $

--- a/lib/Chainweb/Api/PactCommand.hs
+++ b/lib/Chainweb/Api/PactCommand.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Chainweb.Api.PactCommand where
 
@@ -17,6 +18,14 @@ data PactCommand = PactCommand
   , _pactCommand_meta    :: ChainwebMeta
   , _pactCommand_nonce   :: Text
   } deriving (Eq,Show)
+
+instance ToJSON PactCommand where
+  toJSON PactCommand{..} = object
+    [ "payload" .= _pactCommand_payload
+    , "signers" .= _pactCommand_signers
+    , "meta" .= _pactCommand_meta
+    , "nonce" .= _pactCommand_nonce
+    ]
 
 instance FromJSON PactCommand where
   parseJSON = withObject "PactCommand" $ \o -> PactCommand

--- a/lib/Chainweb/Api/PactTypes.hs
+++ b/lib/Chainweb/Api/PactTypes.hs
@@ -1,0 +1,315 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Chainweb.Api.PactTypes where
+
+------------------------------------------------------------------------------
+import           Data.Aeson
+-- import           Data.Hashable
+
+import           Data.Maybe (catMaybes)
+import           Data.Map (Map)
+import           Data.Text (Text)
+-- import qualified Data.Text as T
+-- import           Text.Read (readMaybe)
+import           Data.Foldable (asum)
+import           Data.Scientific
+------------------------------------------------------------------------------
+import Chainweb.Api.Base64Url
+------------------------------------------------------------------------------
+
+data PactGuard = PactGuard
+  { _pactGuard_pactId :: Base64Url Text
+  , _pactGuard_name   :: Text
+  } deriving (Show, Eq)
+
+instance ToJSON PactGuard where
+  toJSON PactGuard{..} = object
+    [ "pactId" .= toJSON _pactGuard_pactId
+    , "name"   .= toJSON _pactGuard_name
+    ]
+
+instance FromJSON PactGuard where
+  parseJSON = withObject "PactGuard" $ \o-> PactGuard
+    <$> o .: "pactId" 
+    <*> o .: "name"
+
+--TODO: Instances are incorrect here
+data ModuleGuard = ModuleGuard   -- Note: Some funky nested json that the datastructure doesn't show
+  { _moduleGuard_guardName       :: Text
+  , _moduleGuard_moduleName      :: Text
+  , _moduleGuard_moduleNamespace :: Maybe Text
+  } deriving (Show, Eq)
+
+instance ToJSON ModuleGuard where
+  toJSON ModuleGuard{..} = object
+    [ "name" .= _moduleGuard_guardName
+    , ("moduleName", object $ catMaybes
+        [ Just $ "name" .= _moduleGuard_moduleName
+        , fmap ("namespace" .=) _moduleGuard_moduleNamespace
+        ]
+      )
+    ]
+instance FromJSON ModuleGuard where
+  parseJSON = withObject "ModuleGuard" $ \o -> do
+    n <- o .: "name"
+    mN <- o .: "moduleName"
+    mN' <- mN .: "name"
+    mNs <- mN .:? "namespace"
+    pure $ ModuleGuard n mN' mNs
+
+
+data UserGuard = UserGuard
+  { _userGuard_args       :: [PactValue]
+  , _userGuard_predFunc   :: Text
+  } deriving (Show, Eq)
+
+instance ToJSON UserGuard where
+  toJSON UserGuard{..} = object
+    [ "args" .= _userGuard_args
+    , "fun"  .= _userGuard_predFunc
+    ]
+instance FromJSON UserGuard where
+  parseJSON = withObject "UserGuard" $ \o -> UserGuard
+    <$> o .: "args"
+    <*> o .: "fun"
+
+data Keyset = Keyset
+  { _keyset_keys :: [Text]
+  , _keyset_pred :: Text
+  }
+  deriving (Eq, Show)
+
+instance FromJSON Keyset where
+  parseJSON = withObject "PactKeyset" $ \o -> Keyset
+    <$> o .: "keys"
+    <*> o .: "pred"
+
+instance ToJSON Keyset where
+  toJSON Keyset{..} = object
+    [ "keys"    .= _keyset_keys
+    , "pred"    .= _keyset_pred
+    ]
+
+newtype KeysetReference = KeysetReference Text
+  deriving (Show, Eq)
+
+instance FromJSON KeysetReference where
+  parseJSON = withObject "KeysetReference" $ \o -> KeysetReference
+    <$> o .: "keysetref"
+
+instance ToJSON KeysetReference where
+  toJSON (KeysetReference ref) = object [ "keysetref" .= ref ]
+
+newtype ModuleReference = ModuleReference Text
+  deriving (Show, Eq)
+
+instance FromJSON ModuleReference where
+  parseJSON = withObject "ModuleReference" $ \o -> ModuleReference
+    <$> o .: "refname"
+
+instance ToJSON ModuleReference where
+  toJSON (ModuleReference ref) = object [ "refname" .= ref ]
+--------------------------------------------------------------
+newtype PactInt = PactInt Int
+  deriving (Eq, Show, Ord, Enum, Num, Real, Bounded)
+
+instance ToJSON PactInt where
+  toJSON (PactInt i) = object ["int" .= i ]
+
+instance FromJSON PactInt where
+  parseJSON = withObject "PactInt" $ \o -> PactInt <$> o .: "int"
+
+newtype PactTime = PactTime Text
+  deriving (Eq, Show)
+
+instance ToJSON PactTime where
+  toJSON (PactTime t) = object ["time" .= t ]
+
+instance FromJSON PactTime where
+  parseJSON = withObject "PactTime" $ \o -> PactTime <$> o .: "time"
+
+data PactValue =
+    PactValue_String          Text
+  | PactValue_Integer         PactInt
+  | PactValue_Decimal         Scientific
+  | PactValue_Boolean         Bool
+  | PactValue_List            [PactValue]
+  | PactValue_ObjectMap       (Map Text PactValue)
+  | PactValue_ModuleReference ModuleReference
+  | PactValue_PactGuard       PactGuard
+  | PactValue_ModuleGuard     ModuleGuard
+  | PactValue_UserGuard       UserGuard
+  | PactValue_Keyset          Keyset
+  | PactValue_KeysetReference KeysetReference
+  | PactValue_Time            PactTime
+  deriving (Eq, Show)
+
+instance FromJSON PactValue where
+  parseJSON (Bool b) = pure $ PactValue_Boolean b
+  parseJSON (String s) = pure $ PactValue_String s
+  parseJSON (Number n) = pure $ PactValue_Decimal n
+  parseJSON a@(Array _) = fmap PactValue_List $ parseJSON a
+  parseJSON o = asum $ fmap (flip ($) o)
+    [ fmap PactValue_Integer . parseJSON
+    , fmap PactValue_ModuleReference . parseJSON
+    , fmap PactValue_PactGuard . parseJSON
+    , fmap PactValue_ModuleGuard . parseJSON
+    , fmap PactValue_UserGuard . parseJSON
+    , fmap PactValue_Keyset . parseJSON
+    , fmap PactValue_KeysetReference . parseJSON
+    , fmap PactValue_Time . parseJSON
+    , fmap PactValue_ObjectMap . parseJSON
+    ]
+
+instance ToJSON PactValue where
+  toJSON pv = case pv of
+    PactValue_String s          -> toJSON s
+    PactValue_Integer i         -> toJSON i
+    PactValue_Decimal d         -> toJSON d
+    PactValue_Boolean b         -> toJSON b
+    PactValue_Time t            -> toJSON t
+    PactValue_List l            -> toJSON l
+    PactValue_ObjectMap m       -> toJSON m
+    PactValue_ModuleReference m -> toJSON m
+    PactValue_PactGuard g       -> toJSON g
+    PactValue_ModuleGuard g     -> toJSON g
+    PactValue_UserGuard g       -> toJSON g
+    PactValue_KeysetReference k -> toJSON k
+    PactValue_Keyset k          -> toJSON k
+--------------------------------------------------------------
+data PactEvent = PactEvent
+  { _pactEvent_name       :: Text
+  , _pactEvent_moduleName :: Text
+  , _pactEvent_params     :: [PactValue]
+  , _pactEvent_moduleHash :: Base64Url Text -- TODO a
+  } deriving (Show, Eq)
+
+instance ToJSON PactEvent where
+  toJSON PactEvent{..} = object
+    [ "name"        .= _pactEvent_name
+    , "module"      .= _pactEvent_moduleName
+    , "params"      .= _pactEvent_params
+    , "moduleHash"  .= _pactEvent_moduleHash
+    ]
+
+instance FromJSON PactEvent where
+  parseJSON = withObject "PactEvent" $ \o -> PactEvent
+    <$> o .: "name"
+    <*> o .: "module"
+    <*> o .: "params"
+    <*> o .: "moduleHash"
+
+data PactContinuationDef = PactContinuationDef
+  { _pactContinuationDef_name  :: Text
+  , _pactContinuationDef_args  :: [ PactValue ]
+  } deriving (Show, Eq)
+
+instance FromJSON PactContinuationDef where
+  parseJSON = withObject "PactContinuationDef" $ \o -> PactContinuationDef
+    <$> o .: "def"
+    <*> o .: "args"
+
+data PactContinuationYield = PactContinuationYield
+  { _pactContiunationYield_data           :: Value  -- Api seems inconsitent, so im punting on this for now
+  , _pactContiunationYield_targetChainId  :: Text
+  , _pactContiunationYield_moduleHash     :: Text 
+  } deriving (Show, Eq)
+
+instance FromJSON PactContinuationYield where
+  parseJSON = withObject "PactContinuationYield" $ \o -> do
+    yieldData <- o .: "data"
+    prov <- o .: "provenance"
+    (tcid, mh) <- case prov of
+      Object subO -> (,)
+        <$> subO .: "targetChainId"
+        <*> subO .: "moduleHash"
+      _ -> fail "PactContinuationYield: expected 'provenenance' found something else"
+    return $ PactContinuationYield yieldData tcid mh
+
+data PactContinuationResult = PactContinuationResult
+  { _pactContinuationResult_pactId          :: Text
+  , _pactContinuationResult_step            :: Int
+  , _pactContinuationResult_stepCount       :: Int
+  , _pactContinuationResult_executed        :: Bool
+  , _pactContinuationResult_stepHasRollback :: Bool
+  , _pactContinuationResult_continuation    :: PactContinuationDef
+  , _pactContinuationResult_yield           :: PactValue
+  } deriving (Show, Eq)
+
+instance FromJSON PactContinuationResult where
+  parseJSON = withObject "PactContinuationResult" $ \o -> PactContinuationResult
+    <$> o .: "pactId"
+    <*> o .: "step"
+    <*> o .: "stepCount"
+    <*> o .: "executed"
+    <*> o .: "stepHasRollback"
+    <*> o .: "continuation"
+    <*> o .: "yield"
+--------------------------------------------------------------
+data PactResult =
+    PactResult_Value PactValue
+  | PactResult_Error PactError
+  deriving (Eq, Show)
+
+instance FromJSON PactResult where
+  parseJSON = withObject "PactResult" $ \o -> do
+    res :: Text <- o .: "status"
+    case res of
+      "success" -> fmap PactResult_Value $ o .: "data"
+      "failure" -> fmap PactResult_Error $ o .: "error"
+      _         -> fail "Not a valid pact result status field"
+
+data PactErrorType =
+    PactErrorType_EvalError
+  | PactErrorType_ArgsError
+  | PactErrorType_DbError
+  | PactErrorType_TxFailure
+  | PactErrorType_SyntaxError
+  | PactErrorType_GasError
+  deriving (Eq, Show)
+
+-- instance ToJSON PactErrorType where
+--   toJSON e = case e of
+--     PactErrorType_EvalError -> String "EvalError"
+--     PactErrorType_ArgsError -> String "ArgsError"
+--     PactErrorType_DbError -> String "DbError"
+--     PactErrorType_TxFailure -> String "TxFailure"
+--     PactErrorType_SyntaxError -> String "SyntaxError"
+--     PactErrorType_GasError -> String "GasError"
+
+instance FromJSON PactErrorType where
+  parseJSON = withText "PactErrorType" $ \case
+    "EvalError"   -> pure PactErrorType_EvalError
+    "ArgsError"   -> pure PactErrorType_ArgsError
+    "DbError"     -> pure PactErrorType_DbError
+    "TxFailure"   -> pure PactErrorType_TxFailure
+    "SyntaxError" -> pure PactErrorType_SyntaxError
+    "GasError"    -> pure PactErrorType_GasError
+    _             -> fail "unknown PactErrorType"
+
+data PactError = PactError
+  { _pactError_message   :: Text
+  , _pactError_callStack :: Maybe [Text]
+  , _pactError_info      :: Maybe Text
+  , _pactError_errorType :: Maybe PactErrorType
+  } deriving (Eq, Show)
+
+-- instance ToJSON PactError where
+--   toJSON PactError{..} = object $ catMaybes
+--     [ Just $ "message"   .=  _pactError_message
+--     , fmap ( "callStack" .=) _pactError_callStack
+--     , fmap ( "info"      .=) _pactError_info
+--     , fmap ( "type"      .=) _pactError_errorType
+--     ]
+instance FromJSON PactError where
+  parseJSON = withObject "PactError" $ \o -> PactError
+    <$> o .:  "message"
+    <*> o .:? "callStack"
+    <*> o .:? "info"
+    <*> o .:? "type"
+

--- a/lib/Chainweb/Api/Payload.hs
+++ b/lib/Chainweb/Api/Payload.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Chainweb.Api.Payload where
 
@@ -13,6 +14,12 @@ data Exec = Exec
   , _exec_data :: Maybe Value
   } deriving (Eq,Show)
 
+instance ToJSON Exec where
+  toJSON Exec{..} = object
+    [ "code" .= _exec_code
+    , "data" .= _exec_data
+    ]
+
 instance FromJSON Exec where
   parseJSON = withObject "Exec" $ \o -> Exec
     <$> o .: "code"
@@ -26,6 +33,15 @@ data Cont = Cont
   , _cont_proof    :: Maybe Text
   } deriving (Eq,Show)
 
+instance ToJSON Cont where
+  toJSON Cont{..} = object
+    [ "pactId" .= _cont_pactId
+    , "rollback" .= _cont_rollback
+    , "step" .= _cont_step
+    , "data" .= _cont_data
+    , "proof" .= _cont_proof
+    ]
+
 instance FromJSON Cont where
   parseJSON = withObject "Cont" $ \o -> Cont
     <$> o .: "pactId"
@@ -36,6 +52,10 @@ instance FromJSON Cont where
 
 data Payload = ExecPayload Exec | ContPayload Cont
   deriving (Eq,Show)
+
+instance ToJSON Payload where
+  toJSON (ExecPayload exec) = Object $ "exec" .= toJSON exec
+  toJSON (ContPayload cont) = Object $ "cont" .= toJSON cont
 
 instance FromJSON Payload where
   parseJSON = withObject "Payload" $ \o -> case HM.lookup "exec" o of

--- a/lib/Chainweb/Api/Sig.hs
+++ b/lib/Chainweb/Api/Sig.hs
@@ -10,6 +10,10 @@ import Data.Text (Text)
 newtype Sig = Sig { unSig :: Text }
   deriving (Eq,Show)
 
+--TODO: Must be b16 according to pact spec
+instance ToJSON Sig where
+  toJSON s = object [ "sig" .= unSig s]
+
 instance FromJSON Sig where
   parseJSON = withObject "Sig" $ \o -> Sig
     <$> o .: "sig"

--- a/lib/Chainweb/Api/Signer.hs
+++ b/lib/Chainweb/Api/Signer.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Chainweb.Api.Signer where
 
 ------------------------------------------------------------------------------
 import Data.Aeson
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, catMaybes)
 import Data.Ord
 import Data.Text (Text)
 ------------------------------------------------------------------------------
@@ -17,6 +18,12 @@ data SigCapability = SigCapability
 instance Ord SigCapability where
   compare = comparing _scName
 
+instance ToJSON SigCapability where
+  toJSON SigCapability{..} = object
+    [ "name" .= _scName
+    , "args" .= _scArgs
+    ]
+
 instance FromJSON SigCapability where
   parseJSON = withObject "SigCapability" $ \o -> SigCapability
     <$> o .: "name"
@@ -28,6 +35,14 @@ data Signer = Signer
   , _signer_pubKey :: Text
   , _signer_capList :: [SigCapability]
   } deriving (Eq,Ord,Show)
+
+instance ToJSON Signer where
+  toJSON Signer{..} = object $ catMaybes
+    [ fmap ("addr" .=) _signer_addr
+    , fmap ("scheme" .=) _signer_scheme
+    , Just $ "pubKey" .= _signer_pubKey
+    , Just $ "clist" .= _signer_capList
+    ]
 
 instance FromJSON Signer where
   parseJSON = withObject "Signer" $ \o -> Signer

--- a/lib/Chainweb/Api/Transaction.hs
+++ b/lib/Chainweb/Api/Transaction.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Chainweb.Api.Transaction where
 
 ------------------------------------------------------------------------------
 import Data.Aeson
+import qualified Data.Text.Encoding as T
+import qualified Data.ByteString.Lazy.Char8 as BSL
 ------------------------------------------------------------------------------
 import Chainweb.Api.Hash
 import Chainweb.Api.PactCommand
@@ -16,8 +19,15 @@ data Transaction = Transaction
   , _transaction_cmd  :: PactCommand
   } deriving (Eq,Show)
 
+instance ToJSON Transaction where
+  toJSON Transaction{..} = object
+    [ "hash" .= _transaction_hash
+    , "sigs" .= _transaction_sigs
+    , "cmd" .= (T.decodeUtf8 $ BSL.toStrict $ encode _transaction_cmd)
+    ]
+
 instance FromJSON Transaction where
   parseJSON = withObject "Transaction" $ \o -> Transaction
     <$> o .: "hash"
     <*> o .: "sigs"
-    <*> (withEmbeddedJSON "sig-embedded" parseJSON =<< (o .: "cmd"))
+    <*> (withEmbeddedJSON "Embedded Cmd" parseJSON =<< (o .: "cmd"))

--- a/lib/Crypto/Hash/Blake2Native.hs
+++ b/lib/Crypto/Hash/Blake2Native.hs
@@ -1,0 +1,331 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      :  Crypto.Hash.Blake2Native
+-- Copyright   :  (C) 2016 Stuart Popejoy
+-- License     :  BSD-style (see the file LICENSE)
+-- Maintainer  :  Stuart Popejoy <stuart@kadena.io>
+--
+-- Native haskell implementation of BLAKE2b.
+-- Adapted from C code in https://github.com/mjosaarinen/blake2_mjosref
+--
+
+module Crypto.Hash.Blake2Native where
+
+import Data.Word
+import Data.Bits
+import Data.ByteString as B (ByteString,index,unpack,pack,length,take,splitAt,null,replicate)
+import Data.Vector as V (Vector,(//),(!),fromList,(++))
+import Control.Lens ((&),(<&>))
+import Prelude as P hiding (last)
+
+type V = Vector
+
+-- | state context
+data Blake2Ctx w = Blake2Ctx
+  { _b :: ByteString -- 128 input buffer
+  , _h :: V w        --   8 chained state
+  , _t0 :: w         --   total number of bytes 0
+  , _t1 :: w         --                         1
+  , _c :: Int        -- pointer for b[]
+  , _outlen :: Int   -- digest size
+  } deriving (Eq)
+instance (Show w) => Show (Blake2Ctx w) where
+  show (Blake2Ctx b h t0 t1 c outlen) =
+    "Blake2Ctx {_b=pack" P.++ show (unpack b) P.++ ", _h=mk" P.++ show h P.++
+    ", _t0=" P.++ show t0 P.++ ", _t1=" P.++ show t1 P.++ ", _c=" P.++ show c P.++
+    ", _outlen=" P.++ show outlen P.++ "}"
+
+
+at :: V a -> Int -> a
+at v i = v ! i
+
+
+upd :: Int -> (V a -> a -> a) -> V a -> V a
+upd i f v = v // [(i,f v (v ! i))]
+
+
+mk :: [a] -> V a
+mk = fromList
+
+cat :: V a -> V a -> V a
+cat = (V.++)
+
+-- | flipped foldl
+ffoldl :: Foldable t => b -> t a -> (b -> a -> b) -> b
+ffoldl i l f = foldl f i l
+
+
+-- | Cyclic right rotation, 64 bit
+rotr64 :: Word64 -> Int -> Word64
+rotr64 x y = (x `shiftR` y) `xor` (x `shiftL` (64 - y))
+
+-- | Cyclic right rotation, 32 bit
+rotr32 :: Word32 -> Int -> Word32
+rotr32 x y = (x `shiftR` y) `xor` (x `shiftL` (32 - y))
+
+-- | Little-endian byte access.
+
+b2b_get64 :: Int -> ByteString -> Word64
+b2b_get64 o p =
+  let ix i = fromIntegral $ index p (o+i)
+  in ix 0               `xor`
+     (ix 1  `shiftL` 8 ) `xor`
+     (ix 2  `shiftL` 16) `xor`
+     (ix 3  `shiftL` 24) `xor`
+     (ix 4  `shiftL` 32) `xor`
+     (ix 5  `shiftL` 40) `xor`
+     (ix 6  `shiftL` 48) `xor`
+     (ix 7  `shiftL` 56)
+
+-- | Little-endian byte access.
+
+b2s_get32 :: Int -> ByteString -> Word32
+b2s_get32 o p =
+  let ix i = fromIntegral $ index p (o+i)
+  in ix 0               `xor`
+     (ix 1  `shiftL` 8 ) `xor`
+     (ix 2  `shiftL` 16) `xor`
+     (ix 3  `shiftL` 24)
+
+type G w = Int -> Int -> Int -> Int -> w -> w -> V w -> V w
+
+-- | G Mixing function, 64bit
+b2b_g :: G Word64
+b2b_g a b c d x' y' v' =
+  v' &
+  upd a (\v x -> x + (v `at` b) + x') &
+  upd d (\v x -> rotr64 (x `xor` (v `at` a)) 32) &
+  upd c (\v x -> x + (v `at` d)) &
+  upd b (\v x -> rotr64 (x `xor` (v `at` c)) 24) &
+  upd a (\v x -> x + (v `at` b) + y') &
+  upd d (\v x -> rotr64 (x `xor` (v `at` a)) 16) &
+  upd c (\v x -> x + (v `at` d)) &
+  upd b (\v x -> rotr64 (x `xor` (v `at` c)) 63)
+
+-- | G Mixing function, 32bit
+b2s_g :: G Word32
+b2s_g a b c d x' y' v' =
+  v' &
+  upd a (\v x -> x + (v `at` b) + x') &
+  upd d (\v x -> rotr32 (x `xor` (v `at` a)) 16) &
+  upd c (\v x -> x + (v `at` d)) &
+  upd b (\v x -> rotr32 (x `xor` (v `at` c)) 12) &
+  upd a (\v x -> x + (v `at` b) + y') &
+  upd d (\v x -> rotr32 (x `xor` (v `at` a)) 8) &
+  upd c (\v x -> x + (v `at` d)) &
+  upd b (\v x -> rotr32 (x `xor` (v `at` c)) 7)
+
+-- | Initialization Vector, 64bit
+blake2b_iv :: V Word64
+blake2b_iv = mk [
+  0x6A09E667F3BCC908, 0xBB67AE8584CAA73B,
+  0x3C6EF372FE94F82B, 0xA54FF53A5F1D36F1,
+  0x510E527FADE682D1, 0x9B05688C2B3E6C1F,
+  0x1F83D9ABFB41BD6B, 0x5BE0CD19137E2179
+  ]
+
+-- | Initialization Vector, 32bit
+blake2s_iv :: V Word32
+blake2s_iv = mk [
+  0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
+  0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19
+  ]
+
+sigma64 :: V (V Int)
+sigma64 = mk [
+  mk [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 ],
+  mk [ 14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3 ],
+  mk [ 11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4 ],
+  mk [ 7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8 ],
+  mk [ 9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13 ],
+  mk [ 2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9 ],
+  mk [ 12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11 ],
+  mk [ 13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10 ],
+  mk [ 6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5 ],
+  mk [ 10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0 ],
+  mk [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 ],
+  mk [ 14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3 ]
+  ]
+
+sigma32 :: V (V Int)
+sigma32 = mk [
+  mk [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 ],
+  mk [ 14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3 ],
+  mk [ 11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4 ],
+  mk [ 7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8 ],
+  mk [ 9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13 ],
+  mk [ 2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9 ],
+  mk [ 12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11 ],
+  mk [ 13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10 ],
+  mk [ 6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5 ],
+  mk [ 10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0 ]
+  ]
+
+
+-- | Compression function, 64bit. "last" flag indicates last block.
+blake2b_compress :: Blake2Ctx Word64 -> Bool -> Blake2Ctx Word64
+blake2b_compress ctx last =
+  let
+    v1 = (_h ctx `cat` blake2b_iv) &
+      upd 12 (\_ x -> (x `xor` _t0 ctx)) &                    -- low 64 bits of offset
+      upd 13 (\_ x -> (x `xor` _t1 ctx)) &                    -- high 64 bits
+      (if last then upd 14 (\_ x -> complement x) else id)     -- last block flag set ?
+    m = mk $ (`map` [0..15]) $ \i -> b2b_get64 (8 * i) (_b ctx)         -- get little-endian words
+    v2 = ffoldl v1 sigma64 $ runRound b2b_g m                        -- 12 rounds
+    h = mk $ (`map` [0..7]) $ \i ->
+          (_h ctx `at` i) `xor` (v2 `at` i) `xor` (v2 `at` (i + 8))
+  in ctx { _h = h }
+
+-- | Compression function, 32bit. "last" flag indicates last block.
+blake2s_compress :: Blake2Ctx Word32 -> Bool -> Blake2Ctx Word32
+blake2s_compress ctx last =
+  let
+    v1 = (_h ctx `cat` blake2s_iv) &
+      upd 12 (\_ x -> (x `xor` _t0 ctx)) &                    -- low 64 bits of offset
+      upd 13 (\_ x -> (x `xor` _t1 ctx)) &                    -- high 64 bits
+      (if last then upd 14 (\_ x -> complement x) else id)     -- last block flag set ?
+    m = mk $ (`map` [0..15]) $ \i -> b2s_get32 (4 * i) (_b ctx)         -- get little-endian words
+    v2 = ffoldl v1 sigma32 $ runRound b2s_g m                        -- 12 rounds
+    h = mk $ (`map` [0..7]) $ \i ->
+          (_h ctx `at` i) `xor` (v2 `at` i) `xor` (v2 `at` (i + 8))
+  in ctx { _h = h }
+
+runRound :: G w -> V w -> V w -> V Int -> V w
+runRound g m v s = v &
+  g 0 4  8 12 (m `at` (s `at`  0)) (m `at` (s `at`  1)) &
+  g 1 5  9 13 (m `at` (s `at`  2)) (m `at` (s `at`  3)) &
+  g 2 6 10 14 (m `at` (s `at`  4)) (m `at` (s `at`  5)) &
+  g 3 7 11 15 (m `at` (s `at`  6)) (m `at` (s `at`  7)) &
+  g 0 5 10 15 (m `at` (s `at`  8)) (m `at` (s `at`  9)) &
+  g 1 6 11 12 (m `at` (s `at` 10)) (m `at` (s `at` 11)) &
+  g 2 7  8 13 (m `at` (s `at` 12)) (m `at` (s `at` 13)) &
+  g 3 4  9 14 (m `at` (s `at` 14)) (m `at` (s `at` 15))
+
+-- | Initialize the hashing context "ctx" with optional key "key".
+--      1 <= outlen <= 64 gives the digest size in bytes.
+--      Secret key (also <= 64 bytes) is optional (keylen = 0).
+blake2b_init :: Word64 -> ByteString -> Either String (Blake2Ctx Word64)
+blake2b_init outlen key
+  | outlen < 1 || outlen > 64 = Left $ "outlen must be > 0 and <= 64 bytes" P.++ show outlen
+  | B.length key > 64 = Left "Key must be <= 64 bytes"
+  | otherwise = Right $
+    let keylen :: Word64
+        keylen = fromIntegral $ B.length key
+        iv = blake2b_iv
+    in Blake2Ctx
+          {
+            -- state, "param block"
+            _h = upd 0 (\_ x -> x `xor` 0x01010000 `xor` (keylen `shiftL` 8) `xor` outlen) iv
+          , _t0 = 0 -- input count low word
+          , _t1 = 0 -- input count high word
+          , _c = 0  -- pointer within buffer
+          , _outlen = fromIntegral outlen
+          , _b = B.replicate 128 0 -- zero input block.
+          } &
+          (\ctx -> if keylen > 0 then blake2b_update key ctx & (\c -> c { _c = 128}) else ctx)
+
+
+-- | Initialize the hashing context "ctx" with optional key "key".
+--      1 <= outlen <= 32 gives the digest size in bytes.
+--      Secret key (also <= 32 bytes) is optional (keylen = 0).
+blake2s_init :: Word32 -> ByteString -> Either String (Blake2Ctx Word32)
+blake2s_init outlen key
+  | outlen < 1 || outlen > 32 = Left $ "outlen must be > 0 and <= 32 bytes" P.++ show outlen
+  | B.length key > 32 = Left "Key must be <= 32 bytes"
+  | otherwise = Right $
+    let keylen :: Word32
+        keylen = fromIntegral $ B.length key
+        iv = blake2s_iv
+    in Blake2Ctx
+          {
+            -- state, "param block"
+            _h = upd 0 (\_ x -> x `xor` 0x01010000 `xor` (keylen `shiftL` 8) `xor` outlen) iv
+          , _t0 = 0 -- input count low word
+          , _t1 = 0 -- input count high word
+          , _c = 0  -- pointer within buffer
+          , _outlen = fromIntegral outlen
+          , _b = B.replicate 64 0 -- zero input block.
+          } &
+          (\ctx -> if keylen > 0 then blake2s_update key ctx & (\c -> c { _c = 64}) else ctx)
+
+-- | Slice a bytestring into segments: 'slice c l bs' means the first
+-- segment will be length c but no longer than l, and the following will
+-- be length l, with the last being whatever remains.
+slice :: Int -> Int -> ByteString -> [ByteString]
+slice c l bs = go (B.splitAt (if c >= l then l else l - c) bs) where
+  go (x,y) | B.null y = [x]
+           | otherwise = x:go (B.splitAt l y)
+
+-- | Add "inlen" bytes from "in" into the hash, 64bit version.
+blake2b_update :: ByteString -> Blake2Ctx Word64 -> Blake2Ctx Word64
+blake2b_update bs ctx
+  | B.null bs = ctx
+  | otherwise = ffoldl ctx (slice (_c ctx) 128 bs) $ \cx s ->
+      resetMaybe cx & cpyBuf s
+  where resetMaybe cx
+          | _c cx < 128 = cx
+          | otherwise =
+              let t0 = _t0 cx + 128
+                  t1 = _t1 cx + (if t0 < 128 then 1 else 0)
+              in (blake2b_compress (cx { _t0 = t0, _t1 = t1 }) False) { _c = 0 }
+        cpyBuf s cx = cx {
+          _b = B.take (_c cx) (_b cx) <> s <> B.replicate (128 - _c cx - B.length s) 0,
+          _c = B.length s + _c cx
+          }
+
+-- | Add "inlen" bytes from "in" into the hash, 32bit version.
+blake2s_update :: ByteString -> Blake2Ctx Word32 -> Blake2Ctx Word32
+blake2s_update bs ctx
+  | B.null bs = ctx
+  | otherwise = ffoldl ctx (slice (_c ctx) 64 bs) $ \cx s ->
+      resetMaybe cx & cpyBuf s
+  where resetMaybe cx
+          | _c cx < 64 = cx
+          | otherwise =
+              let t0 = _t0 cx + 64
+                  t1 = _t1 cx + (if t0 < 64 then 1 else 0)
+              in (blake2s_compress (cx { _t0 = t0, _t1 = t1 }) False) { _c = 0 }
+        cpyBuf s cx = cx {
+          _b = B.take (_c cx) (_b cx) <> s <> B.replicate (64 - _c cx - B.length s) 0,
+          _c = B.length s + _c cx
+          }
+
+-- | Generate the message digest (size given in init), 64bit version.
+blake2b_final :: Blake2Ctx Word64 -> ByteString
+blake2b_final ctx = finalCompress ctx & conv where
+  finalCompress cx =
+    let c = fromIntegral $ _c cx
+        t0 = _t0 cx + c
+        t1 = _t1 cx + (if t0 < c then 1 else 0)
+        b = B.take (_c cx) (_b cx) <> B.replicate (128 - _c cx) 0
+    in blake2b_compress (cx { _t0 = t0, _t1 = t1, _b = b }) True
+  conv cx = B.pack $ (`map` [0 .. pred (_outlen cx)]) $ \i ->
+    fromIntegral $ ((_h cx `at` (i `shiftR` 3)) `shiftR` (8 * (i .&. 7))) .&. 0xFF
+
+
+-- | Generate the message digest (size given in init), 32bit version.
+blake2s_final :: Blake2Ctx Word32 -> ByteString
+blake2s_final ctx = finalCompress ctx & conv where
+  finalCompress cx =
+    let c = fromIntegral $ _c cx
+        t0 = _t0 cx + c
+        t1 = _t1 cx + (if t0 < c then 1 else 0)
+        b = B.take (_c cx) (_b cx) <> B.replicate (64 - _c cx) 0
+    in blake2s_compress (cx { _t0 = t0, _t1 = t1, _b = b }) True
+  conv cx = B.pack $ (`map` [0 .. pred (_outlen cx)]) $ \i ->
+    fromIntegral $ ((_h cx `at` (i `shiftR` 2)) `shiftR` (8 * (i .&. 3))) .&. 0xFF
+
+-- | All together now, 64bit! 'blake2b outlen key inB' hashes inB, with
+-- optional key (empty means no key), to length outlen.
+blake2b :: Int -> ByteString -> ByteString -> Either String ByteString
+blake2b outlen key inB =
+  blake2b_init (fromIntegral outlen) key <&>
+  (blake2b_final . blake2b_update inB)
+
+-- | All together now, 32bit! 'blake2s outlen key inB' hashes inB, with
+-- optional key (empty means no key), to length outlen.
+blake2s :: Int -> ByteString -> ByteString -> Either String ByteString
+blake2s outlen key inB =
+  blake2s_init (fromIntegral outlen) key <&>
+  (blake2s_final . blake2s_update inB)


### PR DESCRIPTION
Attempt at replicating pact-lang-api for hs that is more lightweight than pulling in pact
- Types with json 
- blake hash
Should be deprecated when we do this for real in pact