### PR TITLE
Make creationtime an either in AccountDetail

### DIFF
--- a/lib/ChainwebData/AccountDetail.hs
+++ b/lib/ChainwebData/AccountDetail.hs
@@ -9,7 +9,7 @@ import Data.Time
 import GHC.Generics
 
 data AccountDetail = AccountDetail
-  { _acDetail_creationTime :: UTCTime
+  { _acDetail_creationTime :: Either Text UTCTime
   , _acDetail_blockHash :: Text
   , _acDetail_requestKey :: Text
   , _acDetail_chainid :: Int

--- a/lib/ChainwebData/AccountDetail.hs
+++ b/lib/ChainwebData/AccountDetail.hs
@@ -9,8 +9,7 @@ import Data.Time
 import GHC.Generics
 
 data AccountDetail = AccountDetail
-  { _acDetail_creationTime :: Either Text UTCTime
-  , _acDetail_blockHash :: Text
+  { _acDetail_blockHash :: Text
   , _acDetail_requestKey :: Text
   , _acDetail_chainid :: Int
   , _acDetail_height :: Int


### PR DESCRIPTION
I need this as a shim for when we later properly include creation time in the events table and consequently the transfers table in chainweb-data.