### PR TITLE
Change type of record field _chainwebMeta_chainId

### DIFF
--- a/lib/Chainweb/Api/ChainwebMeta.hs
+++ b/lib/Chainweb/Api/ChainwebMeta.hs
@@ -32,7 +32,7 @@ instance ToJSON ChainwebMeta where
 
 instance FromJSON ChainwebMeta where
   parseJSON = withObject "ChainwebMeta" $ \o -> ChainwebMeta
-    <$>  (o .: "chainId")
+    <$>  o .: "chainId"
     <*> (fromIntegral . unParsedInteger <$> o .: "creationTime")
     <*> (fromIntegral . unParsedInteger <$> o .: "ttl")
     <*> (fromIntegral . unParsedInteger <$> o .: "gasLimit")

--- a/lib/Chainweb/Api/ChainwebMeta.hs
+++ b/lib/Chainweb/Api/ChainwebMeta.hs
@@ -5,15 +5,14 @@ module Chainweb.Api.ChainwebMeta where
 
 ------------------------------------------------------------------------------
 import Data.Aeson
-import Data.Text (Text, unpack)
+import Data.Text (Text)
 import Data.Time.Clock.POSIX
 ------------------------------------------------------------------------------
-import Chainweb.Api.ChainId
 import Chainweb.Api.ParsedNumbers
 ------------------------------------------------------------------------------
 
 data ChainwebMeta = ChainwebMeta
-  { _chainwebMeta_chainId      :: Either Text ChainId
+  { _chainwebMeta_chainId      :: Text
   , _chainwebMeta_creationTime :: POSIXTime
   , _chainwebMeta_ttl          :: Int
   , _chainwebMeta_gasLimit     :: Int
@@ -23,7 +22,7 @@ data ChainwebMeta = ChainwebMeta
 
 instance ToJSON ChainwebMeta where
   toJSON ChainwebMeta{..} = object
-    [ "chainId" .= either unpack (show . unChainId) _chainwebMeta_chainId
+    [ "chainId" .= _chainwebMeta_chainId
     , "creationTime" .= _chainwebMeta_creationTime
     , "ttl" .= _chainwebMeta_ttl
     , "gasLimit" .= _chainwebMeta_gasLimit
@@ -33,12 +32,10 @@ instance ToJSON ChainwebMeta where
 
 instance FromJSON ChainwebMeta where
   parseJSON = withObject "ChainwebMeta" $ \o -> ChainwebMeta
-    <$>  (getChainId <$> (o .: "chainId"))
+    <$>  (o .: "chainId")
     <*> (fromIntegral . unParsedInteger <$> o .: "creationTime")
     <*> (fromIntegral . unParsedInteger <$> o .: "ttl")
     <*> (fromIntegral . unParsedInteger <$> o .: "gasLimit")
     <*> o .: "gasPrice"
     <*> o .: "sender"
 
-getChainId :: Text -> Either Text ChainId
-getChainId t = maybe (Left t) Right $ chainIdFromText t


### PR DESCRIPTION
The chainid in the meta object can be the empty string, or something else that cannot be parsed as a integer (a valid chainId).