### PR TITLE
Add param and header for next tokens in accounts

### DIFF
--- a/lib/ChainwebData/Api.hs
+++ b/lib/ChainwebData/Api.hs
@@ -89,7 +89,8 @@ type AccountApi = "account"
   :> QueryParam "fromheight" BlockHeight
   :> LimitParam
   :> OffsetParam
-  :> Get '[JSON] [AccountDetail]
+  :> NextTokenParam
+  :> Get '[JSON] (NextHeaders [AccountDetail])
 
 data ChainwebDataStats = ChainwebDataStats
   { _cds_transactionCount :: Maybe Int

--- a/lib/ChainwebData/Pagination.hs
+++ b/lib/ChainwebData/Pagination.hs
@@ -30,6 +30,7 @@ import qualified Data.Text as T
 import           Data.Time
 import           Data.Word
 import           Servant.API
+import           Servant.API.ResponseHeaders
 ------------------------------------------------------------------------------
 
 
@@ -124,6 +125,17 @@ type PaginationCache k v = Map k [CacheVal v]
 type PaginationInput k = (k, PaginationQuery)
 type PaginationOutput k v = (k, Maybe (CacheVal v))
 
+------------------------------------------------------------------------------
+-- A token to be used for getting the next batch of results
+
+type NextTokenHeader = Header "Chainweb-Next" NextToken
+type NextHeaders = Headers '[Header "Chainweb-Next" NextToken]
+type NextTokenParam = QueryParam "next" NextToken
+
+newtype NextToken = NextToken { unNextToken :: T.Text }
+
+deriving instance FromHttpApiData NextToken
+deriving instance ToHttpApiData NextToken
 
 ------------------------------------------------------------------------------
 -- | Along with the query results we also need to store the PaginationQuery


### PR DESCRIPTION
This PR extends `chainweb-data`'s `/txs/accounts` endpoint with a `next` query parameter and a `Chainweb-Next` response header used for supporting the batched query result fetching workflow implemented by https://github.com/kadena-io/chainweb-data/pull/103