### PR TITLE
Add Chainweb-Next tokens to search endpoints

### DIFF
--- a/lib/ChainwebData/Api.hs
+++ b/lib/ChainwebData/Api.hs
@@ -46,7 +46,8 @@ type TxSearchApi = "search"
     :> LimitParam
     :> OffsetParam
     :> SearchParam
-    :> Get '[JSON] [TxSummary]
+    :> NextTokenParam
+    :> Get '[JSON] (NextHeaders [TxSummary])
 
 newtype RequestKey = RequestKey Text
 deriving instance FromHttpApiData RequestKey
@@ -80,7 +81,8 @@ type EventsApi = "events"
     :> QueryParam "name" EventName
     :> QueryParam "modulename" EventModuleName
     :> QueryParam "minheight" BlockHeight
-    :> Get '[JSON] [EventDetail]
+    :> NextTokenParam
+    :> Get '[JSON] (NextHeaders [EventDetail])
 
 type AccountApi = "account"
   :> Capture "account-name" Text


### PR DESCRIPTION
This PR adds the new parameters and headers for supporting https://github.com/kadena-io/chainweb-data/pull/109 of `chainweb-data`. This PR needs to be merged before https://github.com/kadena-io/chainweb-data/pull/109 