### PR TITLE
Change transfer amount JSON to string encoded num

### DIFF
--- a/chainweb-api.cabal
+++ b/chainweb-api.cabal
@@ -69,6 +69,7 @@ library
     Chainweb.Api.RespItems
     Chainweb.Api.Sig
     Chainweb.Api.Signer
+    Chainweb.Api.StringEncoded
     Chainweb.Api.Transaction
     ChainwebData.Api
     ChainwebData.EventDetail

--- a/lib/Chainweb/Api/StringEncoded.hs
+++ b/lib/Chainweb/Api/StringEncoded.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Chainweb.Api.StringEncoded where
+
+import qualified  Data.Aeson as A
+
+import GHC.Generics
+import Data.Typeable (Typeable, typeRep)
+import Text.Read (readMaybe)
+import Data.Text (unpack)
+import Data.Maybe (maybeToList)
+
+-- | Wrap "a" so that it is encoded through its Show, Read instances
+newtype StringEncoded a = StringEncoded { getStringEncoded :: a }
+  -- Not deriving Ord, because which Ord? Textual or original?
+  -- Not deriving Num, because it's better to be explicit in the API
+  deriving stock (Eq, Generic)
+
+instance Show a => Show (StringEncoded a) where
+  show = show . show . getStringEncoded
+
+instance Read a => Read (StringEncoded a) where
+  readsPrec i s = [ (StringEncoded a, t)
+    | (str, t) <- readsPrec i s
+    , a <- maybeToList $ readMaybe str
+    ]
+
+instance Show a => A.ToJSON (StringEncoded a) where
+  toJSON = A.toJSON . show . getStringEncoded
+
+instance (Typeable a, Read a) => A.FromJSON (StringEncoded a) where
+  parseJSON = A.withText typeName $ \txt -> case readMaybe $ unpack txt of
+      Just a -> return $ StringEncoded a
+      Nothing -> fail $ "Invalid " ++ typeName ++ ": " ++ show txt
+    where typeName = show $ typeRep ([] :: [StringEncoded a])

--- a/lib/ChainwebData/AccountDetail.hs
+++ b/lib/ChainwebData/AccountDetail.hs
@@ -2,6 +2,7 @@
 
 module ChainwebData.AccountDetail where
 
+import Chainweb.Api.StringEncoded
 import ChainwebData.Util
 import Data.Aeson
 import Data.Scientific
@@ -18,7 +19,7 @@ data AccountDetail = AccountDetail
   , _acDetail_name :: Text
   , _acDetail_fromAccount :: Text
   , _acDetail_toAccount :: Text
-  , _acDetail_amount :: Scientific
+  , _acDetail_amount :: StringEncoded Scientific
   , _acDetail_blockTime :: UTCTime
   } deriving (Eq, Show, Generic)
 


### PR DESCRIPTION
This PR wraps the type of the transfer amount field in order to change its JSON representation to be a string literal containing a number (as opposed to a JSON number literal). 

The reason for this change is that [even though JSON-by-the-spec number literals are arbitrary-precision](https://github.com/kadena-io/chainweb-api/pull/30#issuecomment-1255044266), we've concluded that in practice, parsing JSON number literals with more precision than JS numbers can be unnecessarily hard and fragile using the JSON libraries of many popular languages.

Seems like this representation is commonplace in the blockchain world anyway, so it shouldn't be surprising for most of our users.