### PR TITLE
Rename chainid,name to chain,token

### DIFF
--- a/lib/ChainwebData/TransferDetail.hs
+++ b/lib/ChainwebData/TransferDetail.hs
@@ -13,10 +13,10 @@ import GHC.Generics
 data TransferDetail = TransferDetail
   { _trDetail_blockHash :: Text
   , _trDetail_requestKey :: Text
-  , _trDetail_chainid :: Int
+  , _trDetail_chain :: Int
   , _trDetail_height :: Int
   , _trDetail_idx :: Int
-  , _trDetail_name :: Text
+  , _trDetail_token :: Text
   , _trDetail_fromAccount :: Text
   , _trDetail_toAccount :: Text
   , _trDetail_amount :: StringEncoded Scientific


### PR DESCRIPTION
That's because:
* We have a query parameter called "token" that's used to filter on that field, so no reason to have a different name, and "token" makes more sense anyway
* The same goes with the "chain" query parameter, but "chainid" is also inconsistent with the events and search endpoints