### PR TITLE
Fix the PactNumber JSON parser for integer values

### DIFF
--- a/lib/Chainweb/Api/PactNumber.hs
+++ b/lib/Chainweb/Api/PactNumber.hs
@@ -1,12 +1,8 @@
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE InstanceSigs #-}
 
 module Chainweb.Api.PactNumber where
 
@@ -17,7 +13,6 @@ import           Data.Aeson
 import           Data.Aeson.Types
 import qualified Data.Aeson.Types as A
 import           Data.Decimal
-import           Data.Scientific
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Text.Read (readMaybe)
@@ -29,13 +24,8 @@ data PactNumber = PactInteger Integer | PactDecimal Decimal
   deriving (Eq,Ord,Show)
 
 instance FromJSON PactNumber where
-  parseJSON v@(A.Number s) =
-    -- These sugggested types for the output of floatingOrInteger don't actually matter.
-    -- The decoder actually determines the type of the result.
-    -- These type applications merely exist to suppress compiler warnings.
-    case floatingOrInteger @Double @Integer s of
-      Left _ -> PactDecimal <$> decoder decimalCodec v
-      Right _ -> PactInteger <$> decoder integerCodec v
+  parseJSON :: Value -> Parser PactNumber
+  parseJSON v@A.Number{} = PactDecimal <$> decoder decimalCodec v
   parseJSON v@(Object _) = do
     (PactInteger <$> decoder integerCodec v) <|> (PactDecimal <$> decoder decimalCodec v)
   parseJSON v = A.typeMismatch "Numeric" v


### PR DESCRIPTION
PactNumber parsing from JSON failed whenever we received a Pact `Decimal` value that happened to have an integral value. This PR fixes the parser and brings it in line with the way Pact itself parses its `Literal` values. See:
https://github.com/kadena-io/pact/blob/e704ef56fe9c7c8c34683032bd6dbc3c9086720d/src/Pact/Types/Exp.hs#L155