### PR TITLE
Add Signers list to TxDetail

### DIFF
--- a/lib/ChainwebData/TxDetail.hs
+++ b/lib/ChainwebData/TxDetail.hs
@@ -2,6 +2,7 @@
 
 module ChainwebData.TxDetail where
 
+import Chainweb.Api.Signer (Signer)
 import ChainwebData.Util
 import Data.Aeson
 import Data.Text (Text)
@@ -45,6 +46,7 @@ data TxDetail = TxDetail
   , _txDetail_events :: [TxEvent]
   , _txDetail_initialCode :: Maybe Text
   , _txDetail_previousSteps :: Maybe [Text]
+  , _txDetail_signers :: [Signer]
   } deriving (Eq,Show,Generic)
 
 instance ToJSON TxDetail where

--- a/lib/ChainwebData/TxDetail.hs
+++ b/lib/ChainwebData/TxDetail.hs
@@ -3,6 +3,7 @@
 module ChainwebData.TxDetail where
 
 import Chainweb.Api.Signer (Signer)
+import Chainweb.Api.Sig (Sig)
 import ChainwebData.Util
 import Data.Aeson
 import Data.Text (Text)
@@ -47,6 +48,7 @@ data TxDetail = TxDetail
   , _txDetail_initialCode :: Maybe Text
   , _txDetail_previousSteps :: Maybe [Text]
   , _txDetail_signers :: [Signer]
+  , _txDetail_sigs :: [Sig]
   } deriving (Eq,Show,Generic)
 
 instance ToJSON TxDetail where


### PR DESCRIPTION
This PR adds the signers list to the `TxDetail` type in order to support https://github.com/kadena-io/chainweb-data/pull/152 which is a requirement for adding the signers information to the `txdetail` view of the block explorer.