### PR TITLE
Add PactPollResponses module

### DIFF
--- a/chainweb-api.cabal
+++ b/chainweb-api.cabal
@@ -64,6 +64,7 @@ library
     Chainweb.Api.NodeInfo
     Chainweb.Api.PactCommand
     Chainweb.Api.PactNumber
+    Chainweb.Api.PactPollResponses
     Chainweb.Api.ParsedNumbers
     Chainweb.Api.Payload
     Chainweb.Api.RespItems

--- a/lib/Chainweb/Api/PactPollResponses.hs
+++ b/lib/Chainweb/Api/PactPollResponses.hs
@@ -37,13 +37,13 @@ data CommandResult l = CommandResult
 
 instance FromJSON l => FromJSON (CommandResult l) where
   parseJSON = withObject "CommandResult" $ \o -> CommandResult
-      <$> o .: "requestKey"
+      <$> o .: "reqKey"
       <*> o .:? "txId"
       <*> o .: "result"
       <*> o .: "gas"
       <*> o .:? "logs"
       <*> o .:? "continuation"
-      <*> o .:? "metadata"
+      <*> o .:? "metaData"
       <*> (events <$> o .: "events")
     where
       events Nothing = []

--- a/lib/Chainweb/Api/PactPollResponses.hs
+++ b/lib/Chainweb/Api/PactPollResponses.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Chainweb.Api.PactPollResponses where
+
+------------------------------------------------------------------------------
+import           Data.Aeson
+import           Data.Hashable (Hashable)
+import qualified Data.HashMap.Strict as HM
+import           Data.Int
+import           Data.Text (Text)
+import           Data.Word
+------------------------------------------------------------------------------
+
+newtype RequestKey = RequestKey { unRequestKey :: Text }
+  deriving (Eq, Ord, Show, Hashable, FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+
+newtype TxId = TxId Word64
+  deriving (Eq, Ord, Show, FromJSON, ToJSON)
+
+newtype PactResult = PactResult { unPactResult :: Either Value Value }
+  deriving (Eq, Show, FromJSON, ToJSON)
+
+newtype Gas = Gas Int64
+  deriving (Eq, Ord, Show, FromJSON, ToJSON)
+
+data CommandResult l = CommandResult
+  { _crReqKey :: !RequestKey
+  , _crTxId :: !(Maybe TxId)
+  , _crResult :: !PactResult
+  , _crGas :: !Gas
+  , _crLogs :: !(Maybe l)
+  , _crContinuation :: !(Maybe Value) -- just accept the json?
+  , _crMetaData :: !(Maybe Value)
+  , _crEvents :: [Value] -- just accept the json?
+  } deriving (Eq, Show)
+
+instance FromJSON l => FromJSON (CommandResult l) where
+  parseJSON = withObject "CommandResult" $ \o -> CommandResult
+      <$> o .: "requestKey"
+      <*> o .:? "txId"
+      <*> o .: "result"
+      <*> o .: "gas"
+      <*> o .:? "logs"
+      <*> o .:? "continuation"
+      <*> o .:? "metadata"
+      <*> (events <$> o .: "events")
+    where
+      events Nothing = []
+      events (Just es) = es
+
+newtype PactHash = PactHash { unHash :: Text }
+  deriving (Eq, Ord, Show, FromJSON, ToJSON)
+
+newtype PollResponses = PollResponses
+  { _prResults :: HM.HashMap RequestKey (CommandResult PactHash)
+  } deriving (Eq, Show)
+
+instance FromJSON PollResponses where
+  parseJSON v = PollResponses <$> withObject "PollResponses" (\_ -> parseJSON v) v

--- a/lib/Chainweb/Api/PactPollResponses.hs
+++ b/lib/Chainweb/Api/PactPollResponses.hs
@@ -4,6 +4,7 @@
 module Chainweb.Api.PactPollResponses where
 
 ------------------------------------------------------------------------------
+import           Control.Applicative ((<|>))
 import           Data.Aeson
 import           Data.Hashable (Hashable)
 import qualified Data.HashMap.Strict as HM
@@ -13,16 +14,21 @@ import           Data.Word
 ------------------------------------------------------------------------------
 
 newtype RequestKey = RequestKey { unRequestKey :: Text }
-  deriving (Eq, Ord, Show, Hashable, FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+  deriving (Eq, Ord, Show, Hashable, FromJSON, FromJSONKey)
 
 newtype TxId = TxId Word64
-  deriving (Eq, Ord, Show, FromJSON, ToJSON)
+  deriving (Eq, Ord, Show, FromJSON)
 
 newtype PactResult = PactResult { unPactResult :: Either Value Value }
-  deriving (Eq, Show, FromJSON, ToJSON)
+  deriving (Eq, Show)
+
+
+instance FromJSON PactResult where
+  parseJSON (Object o) = PactResult <$> (Right <$> o .: "data" <|> Left <$> o .: "error")
+  parseJSON p = fail $ "Invalid PactResult: " ++ show p
 
 newtype Gas = Gas Int64
-  deriving (Eq, Ord, Show, FromJSON, ToJSON)
+  deriving (Eq, Ord, Show, FromJSON)
 
 data CommandResult l = CommandResult
   { _crReqKey :: !RequestKey
@@ -50,7 +56,7 @@ instance FromJSON l => FromJSON (CommandResult l) where
       events (Just es) = es
 
 newtype PactHash = PactHash { unHash :: Text }
-  deriving (Eq, Ord, Show, FromJSON, ToJSON)
+  deriving (Eq, Ord, Show, FromJSON)
 
 newtype PollResponses = PollResponses
   { _prResults :: HM.HashMap RequestKey (CommandResult PactHash)


### PR DESCRIPTION
This is a small step in reducing downstream projects' reliance on pact types. Some projects can't keep apace with both pact's (and chainweb's) need to use very recently published GHC versions.