### PR TITLE
Fix the FromJSON instance for Payload

### DIFF
--- a/lib/Chainweb/Api/Payload.hs
+++ b/lib/Chainweb/Api/Payload.hs
@@ -59,8 +59,8 @@ instance ToJSON Payload where
 
 instance FromJSON Payload where
   parseJSON = withObject "Payload" $ \o -> do
-    o .: "exec" >>= \case
-      Nothing -> o .: "cont" >>= \case
+    o .:? "exec" >>= \case
+      Nothing -> o .:? "cont" >>= \case
         Nothing -> fail "Payload must be exec or cont"
         Just cont -> return $ ContPayload cont
       Just exec -> return $ ExecPayload exec


### PR DESCRIPTION
This PR fixes a regression introduced by #52. The rewrite of the `FromJSON` instance in that PR changed the behavior when the `exec` field doesn't exist.