### PR TITLE
Adjust the version encoder for fast-development rename

### DIFF
--- a/lib/Chainweb/Api/BlockHeader.hs
+++ b/lib/Chainweb/Api/BlockHeader.hs
@@ -124,8 +124,8 @@ encodeChainId = putWord32le . fromIntegral . unChainId
 {-# INLINE encodeChainId #-}
 
 encodeChainwebVersion :: Putter Text
-encodeChainwebVersion "development" = putWord32le 0x01
-encodeChainwebVersion "fast-development" = putWord32le 0x02
+encodeChainwebVersion "recap-development" = putWord32le 0x01
+encodeChainwebVersion "development" = putWord32le 0x02
 encodeChainwebVersion "mainnet01" = putWord32le 0x05
 encodeChainwebVersion "testnet04" = putWord32le 0x07
 encodeChainwebVersion v = error $ "chainweb version " <> unpack v <> " does not exist"
@@ -192,8 +192,8 @@ decodeAdjacents = label "Adjacents" $ do
 
 decodeChainwebVersion :: Get Text
 decodeChainwebVersion = label "ChainwebVersion" $ getWord32le >>= \case
-  0x01 -> return "development"
-  0x02 -> return "fast-development"
+  0x01 -> return "recap-development"
+  0x02 -> return "development"
   0x05 -> return "mainnet01"
   0x07 -> return "testnet04"
   x -> fail $ "chainweb version " <> show x <> " does not exist"


### PR DESCRIPTION
This PR brings the `{encode,decode}ChainwebVersion` functions in line with the recent `fast-development` -> `development` & `development` -> `recap-development` changes that went into `chainweb`. 